### PR TITLE
Fix mock user admin

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -36,7 +36,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const login = (newToken: string) => {
     setToken(newToken);
     localStorage.setItem("token", newToken);
-    setUser(jwtDecode(newToken));
+    if (newToken !== "admin" && newToken) setUser(jwtDecode(newToken));
   };
 
   const logout = () => {
@@ -49,7 +49,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     const savedToken = localStorage.getItem("token");
     if (savedToken) {
       setToken(savedToken);
-      setUser(jwtDecode(savedToken));
+      if (savedToken !== "admin" && savedToken) setUser(jwtDecode(savedToken));
     }
   }, []);
 

--- a/src/context/PreventRightClickContext.tsx
+++ b/src/context/PreventRightClickContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useEffect } from "react";
 import PropTypes from "prop-types";
 import React from "react";
 
-const PreventRightClickContext = createContext(null);
+export const PreventRightClickContext = createContext(null);
 
 export function PreventRightClickProvider({ children }) {
   useEffect(() => {


### PR DESCRIPTION
This pull request fixes an issue with the mock user admin. The `AuthProvider` component now checks if the token is "admin" before setting the user. Additionally, the `PreventRightClickContext` has been exported from the file it was defined in.