### PR TITLE
Refactor terminology for bibliographic sources

### DIFF
--- a/src/pages/Details/PaintingDetail/index.tsx
+++ b/src/pages/Details/PaintingDetail/index.tsx
@@ -170,7 +170,7 @@ const PaintingDetails = () => {
               </p>
               <br />
               <p className="record-data">
-                <strong>Fonte Bibliográfica:</strong>{" "}
+                <strong>Fonte Historiográfica:</strong>{" "}
                 {data?.bibliographySource ?? "N/A"}
               </p>
             </div>

--- a/src/pages/SubmitPage/index.tsx
+++ b/src/pages/SubmitPage/index.tsx
@@ -808,8 +808,16 @@ const SubmitPage: React.FC<{ painting?: any; isEdit?: boolean }> = ({
       });
       setChurchImages([]);
     } catch (error) {
+      const errorResponse = error?.response?.data?.errors || null;
+      let formattedErrorMessages = formatErrorMessages(errorResponse);
+
       console.error("Error posting new church:", error);
-      toast.error(`Erro ao adicionar igreja: ${error.message}`);
+      toast.error(`Erro ao adicionar igreja: ${formattedErrorMessages}`, {
+        style: {
+          fontSize: "16px",
+          padding: "20px",
+        },
+      });
     }
   };
 

--- a/src/pages/SubmitPage/index.tsx
+++ b/src/pages/SubmitPage/index.tsx
@@ -915,12 +915,12 @@ const SubmitPage: React.FC<{ painting?: any; isEdit?: boolean }> = ({
             />
           </label>
           <p style={{ fontSize: 12 }}>
-            Observação: Fontes bibliográficas devem ser separadas por ponto e
+            Observação: Fontes historiográfica devem ser separadas por ponto e
             vírgula.
           </p>
           <div className="grid-layout">
             <label className="label-wrapper">
-              <p className="input-label">Fontes Bibliográficas</p>
+              <p className="input-label">Fontes Historiográfica</p>
               <textarea
                 placeholder="Exemplo: fonte1; fonte2; fonte3"
                 value={obra.bibliographicSources}


### PR DESCRIPTION
This pull request includes a refactoring of the code to update the terminology used for bibliographic sources to historiographic sources. This change ensures consistency and accuracy in the terminology used throughout the codebase.

"Handle error response in SubmitPage's add church function"