### PR TITLE
Fix error handling for SubmitPage's artwork update

### DIFF
--- a/src/pages/SubmitPage/index.tsx
+++ b/src/pages/SubmitPage/index.tsx
@@ -555,7 +555,7 @@ const SubmitPage: React.FC<{ painting?: any; isEdit?: boolean }> = ({
 
       if (formattedErrorMessages === "") {
         formattedErrorMessages =
-          "Por favor, adicione os campos necessários indicados com *";
+          "Imagem muito grande ou inválida. Por favor, tente novamente com uma imagem menor.";
       }
 
       console.error("Error posting data:", error);
@@ -810,6 +810,11 @@ const SubmitPage: React.FC<{ painting?: any; isEdit?: boolean }> = ({
     } catch (error) {
       const errorResponse = error?.response?.data?.errors || null;
       let formattedErrorMessages = formatErrorMessages(errorResponse);
+
+      if (formattedErrorMessages === "") {
+        formattedErrorMessages =
+          "Imagem muito grande ou inválida. Por favor, tente novamente com uma imagem menor.";
+      }
 
       console.error("Error posting new church:", error);
       toast.error(`Erro ao adicionar igreja: ${formattedErrorMessages}`, {

--- a/src/pages/SubmitPage/index.tsx
+++ b/src/pages/SubmitPage/index.tsx
@@ -689,7 +689,9 @@ const SubmitPage: React.FC<{ painting?: any; isEdit?: boolean }> = ({
       setGravuras([]);
     } catch (error) {
       console.error("Error updating data:", error);
-      toast.error(`Erro ao atualizar a obra: ${error.message}`, {
+
+      // TODO fix error handling
+      toast.error(`Erro ao atualizar a obra: ${error.response.data.detail}`, {
         duration: 3000,
         style: {
           fontSize: "16px",


### PR DESCRIPTION
This pull request fixes the error handling for the artwork update on the SubmitPage. Previously, the error message for an invalid image was not clear. This PR updates the error message to indicate that the image is either too large or invalid and suggests trying again with a smaller image.