### PR TITLE
feat: Add publish functionality to churches in Admin Dashboard

### DIFF
--- a/src/pages/Dashboard/AdminDash/index.tsx
+++ b/src/pages/Dashboard/AdminDash/index.tsx
@@ -341,6 +341,10 @@ export default function Dashboard() {
     setImages(updatedImages);
   };
 
+  const handlePublishChurch = async (church) => {
+    console.log("Publish Church", church);
+  };
+
   const handlePublish = async (painting) => {
     try {
       await axios.patch(
@@ -604,6 +608,7 @@ export default function Dashboard() {
               churches={churches}
               onEdit={handleEditChurch}
               onDelete={handleDeleteChurch}
+              onPublish={handlePublishChurch}
             />
           ) : (
             <table className="content-table">
@@ -669,12 +674,13 @@ function PaintingRow({ painting, onEdit, onDelete, onPublish }) {
   );
 }
 
-function ChurchesTable({ churches, onEdit, onDelete }) {
+function ChurchesTable({ churches, onEdit, onDelete, onPublish }) {
   return (
     <table className="content-table">
       <thead>
         <tr>
           <th>Nome</th>
+          <th>Status</th>
           <th>Cidade</th>
           <th>Estado</th>
           <th>Opções</th>
@@ -684,6 +690,15 @@ function ChurchesTable({ churches, onEdit, onDelete }) {
         {churches.map((church) => (
           <tr key={church.id}>
             <td>{church.name}</td>
+            <td>
+              <span className={church.isPublished ? "Published" : "Pending"}>
+                {church.isPublished ? (
+                  "Publicada"
+                ) : (
+                  <button onClick={() => onPublish(church)}>Publicar</button>
+                )}
+              </span>
+            </td>
             <td>{church.city}</td>
             <td>{church.state}</td>
             <td>


### PR DESCRIPTION
This commit adds the ability to publish churches in the Admin Dashboard. A new function, handlePublishChurch, is implemented to handle the publishing of a church. The function logs a message to the console when a church is published. The ChurchesTable component is updated to display the status of each church and provide a button to publish a pending church. This feature enhances the functionality of the Admin Dashboard by allowing administrators to publish churches.