### PR TITLE
refactor: Split bibliography sources by new line in SubmitPage

### DIFF
--- a/src/pages/SubmitPage/index.tsx
+++ b/src/pages/SubmitPage/index.tsx
@@ -534,7 +534,9 @@ const SubmitPage: React.FC<{ painting?: any; isEdit?: boolean }> = ({
         photographer: img.Photographer,
       })),
       dateOfCreation: obra.dateOfCreation,
-      bibliographySource: [obra.bibliographicSources],
+      bibliographySource: obra.bibliographicSources
+        .split("\n")
+        .filter((source) => source.trim() !== ""),
       bibliographyReference: [obra.bibliographicReferences],
       engravingRequests: gravuras.map((gravura) => ({
         name: gravura.Name,


### PR DESCRIPTION
The code changes in SubmitPage modify the `bibliographySource` property of the `obra` object. Previously, the property was a single string, but now it is split into an array of strings using the newline character as the delimiter. This change allows for better organization and filtering of the bibliography sources.