### PR TITLE
Remove logo

### DIFF
--- a/src/assistant.tsx
+++ b/src/assistant.tsx
@@ -124,7 +124,7 @@ const Assistant: React.FC<AssistantProps> = ({
           }}
         >
           <h1>Museu Barroco IA</h1>
-          <img height={"15px"} src={openAISvg} alt="OpenAI logo" />
+          {/* <img height={"15px"} src={openAISvg} alt="OpenAI logo" /> */}
         </div>
         <button onClick={() => setShowAssistant(false)}>x</button>
       </div>


### PR DESCRIPTION
This pull request removes the logo from the Museu Barroco IA application. The logo was commented out in the code, so it is no longer displayed on the page.