### PR TITLE
Wrap SearchBar for consistent width in ChurchState component

### DIFF
--- a/src/pages/ChurchState/index.tsx
+++ b/src/pages/ChurchState/index.tsx
@@ -105,10 +105,12 @@ const ChurchState = () => {
           {translateState(state)}
         </span>
         <SearchBarContainer>
-          <SearchBar
-            placeHolder={`Busque em ${capitalize(state)}`}
-            showButtons={false}
-          />
+          <div style={{ width: "100%" }}>
+            <SearchBar
+              placeHolder={`Busque em ${capitalize(state)}`}
+              showButtons={false}
+            />
+          </div>
         </SearchBarContainer>
       </SearchHeader>
 

--- a/src/pages/SearchPage/styles.ts
+++ b/src/pages/SearchPage/styles.ts
@@ -9,6 +9,7 @@ export const SearchContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 6.4rem;
+  width: 100%;
 `;
 
 export const SearchBarContainer = styled.div`


### PR DESCRIPTION
Ensure the SearchBar maintains a consistent width by wrapping it in a div and updating the SearchContainer styles for clarity.